### PR TITLE
Add basic entities from Notion

### DIFF
--- a/cms/src/collections/APIs.ts
+++ b/cms/src/collections/APIs.ts
@@ -1,0 +1,30 @@
+import { CollectionConfig } from 'payload/types'
+
+const APIs: CollectionConfig = {
+  slug: 'apis',
+  labels: {
+    singular: 'API',
+    plural: 'APIs',
+  },
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'project',
+      type: 'relationship',
+      relationTo: 'projects',
+      hasMany: false,
+    },
+  ],
+}
+
+export default APIs

--- a/cms/src/collections/Hackathons.ts
+++ b/cms/src/collections/Hackathons.ts
@@ -1,0 +1,27 @@
+import { CollectionConfig } from 'payload/types'
+
+const Hackathons: CollectionConfig = {
+  slug: 'hackathons',
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'organizations',
+      type: 'relationship',
+      relationTo: 'organizations',
+      hasMany: true,
+    },
+    // TODO: #hackathon-1 Populate back-reference to Projects,
+  ],
+}
+
+export default Hackathons

--- a/cms/src/collections/Organizations.ts
+++ b/cms/src/collections/Organizations.ts
@@ -1,0 +1,26 @@
+import { CollectionConfig } from 'payload/types'
+
+const Organizations: CollectionConfig = {
+  slug: 'organizations',
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'tags',
+      type: 'select',
+      options: ['Civic', 'Government'],
+    },
+    // TODO: #org-1 Populate back-reference to Projects,
+  ],
+}
+
+export default Organizations

--- a/cms/src/collections/Pains.ts
+++ b/cms/src/collections/Pains.ts
@@ -1,0 +1,27 @@
+import { CollectionConfig } from 'payload/types'
+
+const Pains: CollectionConfig = {
+  slug: 'pains',
+  admin: {
+    useAsTitle: 'problem',
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'problem',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'organizations',
+      type: 'relationship',
+      relationTo: 'organizations',
+      hasMany: true,
+    },
+    // TODO: #pain-1 Populate back-reference to Projects,
+  ],
+}
+
+export default Pains

--- a/cms/src/collections/Projects.ts
+++ b/cms/src/collections/Projects.ts
@@ -3,26 +3,68 @@ import { CollectionConfig } from 'payload/types'
 const Projects: CollectionConfig = {
   slug: 'projects',
   admin: {
-    useAsTitle: 'title',
+    useAsTitle: 'name',
   },
   access: {
     read: () => true,
   },
   fields: [
     {
-      name: 'title',
+      name: 'name',
       type: 'text',
       required: true,
     },
     {
       name: 'slug',
       type: 'text',
-      required: false,
     },
     {
-      name: 'description',
-      type: 'text',
-      required: false,
+      name: 'status',
+      type: 'select',
+      options: [
+        {
+          label: 'Not Started',
+          value: 'NOT_STARTED',
+        },
+        {
+          label: 'In Development',
+          value: 'IN_DEVELOPMENT',
+        },
+        {
+          label: 'Released',
+          value: 'RELEASED',
+        },
+        {
+          label: 'Done',
+          value: 'DONE',
+        },
+      ],
+      required: true,
+    },
+    {
+      name: 'organizations',
+      type: 'relationship',
+      relationTo: 'organizations',
+      hasMany: true,
+    },
+    {
+      name: 'apis',
+      label: 'APIs',
+      type: 'relationship',
+      relationTo: 'apis',
+      hasMany: true,
+    },
+    {
+      name: 'pains',
+      type: 'relationship',
+      relationTo: 'pains',
+      hasMany: true,
+    },
+    {
+      name: 'hackathons',
+      type: 'relationship',
+      relationTo: 'hackathons',
+      hasMany: true,
     },
   ],
 }

--- a/cms/src/collections/Services.ts
+++ b/cms/src/collections/Services.ts
@@ -1,0 +1,34 @@
+import { CollectionConfig } from 'payload/types'
+
+const Services: CollectionConfig = {
+  slug: 'services',
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'project',
+      type: 'relationship',
+      relationTo: 'projects',
+      hasMany: true,
+    },
+    {
+      name: 'apis',
+      label: 'APIs',
+      type: 'relationship',
+      relationTo: 'apis',
+      hasMany: true,
+    },
+    // TODO: #service-1 add virtual field "Organization" by populating projects' organizations
+  ],
+}
+
+export default Services

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -1,14 +1,27 @@
 import { buildConfig } from 'payload/config'
 import path from 'path'
 
-import Users from './collections/Users'
+import APIs from './collections/APIs'
+import Hackathons from './collections/Hackathons'
+import Organizations from './collections/Organizations'
+import Pains from './collections/Pains'
 import Projects from './collections/Projects'
+import Services from './collections/Services'
+import Users from './collections/Users'
 
 export default buildConfig({
   admin: {
     user: Users.slug,
   },
-  collections: [Users, Projects],
+  collections: [
+    APIs,
+    Hackathons,
+    Organizations,
+    Pains,
+    Projects,
+    Services,
+    Users,
+  ],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },


### PR DESCRIPTION
Adds the following collections:
- APIs
- Hackathons
- Organizations
- Pains
- Projects (modified)
- Services

<img width="1163" alt="image" src="https://github.com/kaogeek/hack-th/assets/24814968/f5544fe0-ac1c-4c7f-92c2-18850051f359">
