### PR TITLE
Add Backpopulate field

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,4 @@ yarn.lock
 dist/
 .astro
 .cache
+payload-types.ts

--- a/cms/src/collections/APIs.ts
+++ b/cms/src/collections/APIs.ts
@@ -20,6 +20,7 @@ const APIs: CollectionConfig = {
       required: true,
     },
     BackpopulateField({
+      name: 'projects',
       relationFrom: 'projects',
       relationField: 'apis',
       label: 'Projects',

--- a/cms/src/collections/APIs.ts
+++ b/cms/src/collections/APIs.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from 'payload/types'
+import { BackpopulateField } from '../fields/Backpopulate'
 
 const APIs: CollectionConfig = {
   slug: 'apis',
@@ -18,12 +19,12 @@ const APIs: CollectionConfig = {
       type: 'text',
       required: true,
     },
-    {
-      name: 'project',
-      type: 'relationship',
-      relationTo: 'projects',
-      hasMany: false,
-    },
+    BackpopulateField({
+      relationFrom: 'projects',
+      relationField: 'apis',
+      label: 'Projects',
+      collectionSlug: 'apis',
+    }),
   ],
 }
 

--- a/cms/src/collections/Hackathons.ts
+++ b/cms/src/collections/Hackathons.ts
@@ -22,6 +22,7 @@ const Hackathons: CollectionConfig = {
       hasMany: true,
     },
     BackpopulateField({
+      name: 'projects',
       relationFrom: 'projects',
       relationField: 'hackathons',
       label: 'Projects',

--- a/cms/src/collections/Hackathons.ts
+++ b/cms/src/collections/Hackathons.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from 'payload/types'
+import { BackpopulateField } from '../fields/Backpopulate'
 
 const Hackathons: CollectionConfig = {
   slug: 'hackathons',
@@ -20,7 +21,12 @@ const Hackathons: CollectionConfig = {
       relationTo: 'organizations',
       hasMany: true,
     },
-    // @todo #2 Populate back-reference to Projects,
+    BackpopulateField({
+      relationFrom: 'projects',
+      relationField: 'hackathons',
+      label: 'Projects',
+      collectionSlug: 'hackathons',
+    }),
   ],
 }
 

--- a/cms/src/collections/Organizations.ts
+++ b/cms/src/collections/Organizations.ts
@@ -21,6 +21,7 @@ const Organizations: CollectionConfig = {
       options: ['Civic', 'Government'],
     },
     BackpopulateField({
+      name: 'projects',
       relationFrom: 'projects',
       relationField: 'organizations',
       label: 'Projects',

--- a/cms/src/collections/Organizations.ts
+++ b/cms/src/collections/Organizations.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from 'payload/types'
+import { BackpopulateField } from '../fields/Backpopulate'
 
 const Organizations: CollectionConfig = {
   slug: 'organizations',
@@ -19,7 +20,12 @@ const Organizations: CollectionConfig = {
       type: 'select',
       options: ['Civic', 'Government'],
     },
-    // @todo #3 Populate back-reference to Projects,
+    BackpopulateField({
+      relationFrom: 'projects',
+      relationField: 'organizations',
+      label: 'Projects',
+      collectionSlug: 'organizations',
+    }),
   ],
 }
 

--- a/cms/src/collections/Pains.ts
+++ b/cms/src/collections/Pains.ts
@@ -22,6 +22,7 @@ const Pains: CollectionConfig = {
       hasMany: true,
     },
     BackpopulateField({
+      name: 'projects',
       relationFrom: 'projects',
       relationField: 'pains',
       label: 'Projects',

--- a/cms/src/collections/Pains.ts
+++ b/cms/src/collections/Pains.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from 'payload/types'
+import { BackpopulateField } from '../fields/Backpopulate'
 
 const Pains: CollectionConfig = {
   slug: 'pains',
@@ -20,7 +21,12 @@ const Pains: CollectionConfig = {
       relationTo: 'organizations',
       hasMany: true,
     },
-    // @todo #4 Populate back-reference to Projects,
+    BackpopulateField({
+      relationFrom: 'projects',
+      relationField: 'pains',
+      label: 'Projects',
+      collectionSlug: 'pains',
+    }),
   ],
 }
 

--- a/cms/src/fields/Backpopulate.ts
+++ b/cms/src/fields/Backpopulate.ts
@@ -1,0 +1,105 @@
+import { RelationshipField } from 'payload/dist/fields/config/types'
+import { PaginatedDocs } from 'payload/dist/mongoose/types'
+import { Config } from 'payload/generated-types'
+import { Field, FieldHook } from 'payload/types'
+
+type BackpopulateHookOptions<TSlug extends keyof Config['collections']> = Pick<
+  BackpopulateFieldOptions<TSlug>,
+  'relationFrom' | 'relationField' | 'collectionSlug'
+>
+
+function backpopulateHook<TSlug extends keyof Config['collections']>({
+  relationFrom,
+  relationField,
+  collectionSlug,
+}: BackpopulateHookOptions<TSlug>): FieldHook {
+  return async ({ req, data }) => {
+    const { payload } = req
+
+    const fromCollection = payload.config.collections.find(
+      collection => collection.slug === relationFrom
+    )
+    const field = fromCollection.fields.find(
+      field => field.type == 'relationship' && field.name === relationField
+    ) as RelationshipField // safe to cast because we checked for type
+    if (!field) {
+      throw new Error(
+        `Could not find relationship field "${relationField}" in collection "${fromCollection.slug}" or `
+      )
+    }
+
+    let relatedDocs: PaginatedDocs<Config['collections'][TSlug]>
+    if (Array.isArray(field.relationTo)) {
+      // TODO: backpopulate-1 handle backpopulation for polymorphic relationships
+      throw new Error('polymorphic relationship backpopulation not implemented')
+    } else if (field.relationTo === collectionSlug) {
+      relatedDocs = await payload.find({
+        collection: relationFrom,
+        pagination: false,
+        where: {
+          [relationField]: {
+            contains: data.id,
+          },
+        },
+        depth: 0,
+      })
+    }
+
+    const relatedIds = relatedDocs.docs.map(doc => doc.id)
+    return relatedIds
+  }
+}
+
+export interface BackpopulateFieldOptions<
+  TSlug extends keyof Config['collections']
+> {
+  /**
+   * The collection to backpopulate relation from
+   */
+  relationFrom: TSlug
+
+  /**
+   * The field to backpopulate relation from
+   */
+  relationField: keyof Config['collections'][TSlug] & string
+
+  /**
+   * The label to display in the admin UI
+   */
+  label: string
+
+  // TODO: backpopulate-2 find a way to use collection from afterRead hook argument instead.
+  /**
+   * The collection of this field. This must be set to the slug of the collection this field belongs to.
+   */
+  collectionSlug: keyof Config['collections']
+}
+
+export function BackpopulateField<TSlug extends keyof Config['collections']>({
+  relationFrom,
+  relationField,
+  collectionSlug,
+  label,
+}: BackpopulateFieldOptions<TSlug>): Field {
+  relationFrom
+  return {
+    name: `backpopulate_${relationFrom}_${relationField}`,
+    type: 'relationship',
+    label: label,
+    // TODO: backpopulate-3 remove field from list view
+    admin: {
+      readOnly: true,
+    },
+    relationTo: relationFrom,
+    hasMany: true,
+    hooks: {
+      afterRead: [
+        backpopulateHook({
+          relationFrom,
+          relationField,
+          collectionSlug,
+        }),
+      ],
+    },
+  }
+}

--- a/cms/src/fields/Backpopulate.ts
+++ b/cms/src/fields/Backpopulate.ts
@@ -50,6 +50,10 @@ function backpopulateHook<TSlug extends keyof Config['collections']>({
   }
 }
 
+const clearFieldData: FieldHook = () => {
+  return null
+}
+
 export interface BackpopulateFieldOptions<
   TSlug extends keyof Config['collections']
 > {
@@ -99,6 +103,7 @@ export function BackpopulateField<TSlug extends keyof Config['collections']>({
           collectionSlug,
         }),
       ],
+      beforeChange: [clearFieldData],
     },
   }
 }

--- a/cms/src/fields/Backpopulate.ts
+++ b/cms/src/fields/Backpopulate.ts
@@ -86,7 +86,6 @@ export function BackpopulateField<TSlug extends keyof Config['collections']>({
     name: `backpopulate_${relationFrom}_${relationField}`,
     type: 'relationship',
     label: label,
-    // TODO: backpopulate-3 remove field from list view
     admin: {
       readOnly: true,
     },

--- a/cms/src/fields/Backpopulate.ts
+++ b/cms/src/fields/Backpopulate.ts
@@ -58,6 +58,11 @@ export interface BackpopulateFieldOptions<
   TSlug extends keyof Config['collections']
 > {
   /**
+   * The name of the field. Must be unique within the collection.
+   */
+  name: string
+
+  /**
    * The collection to backpopulate relation from
    */
   relationFrom: TSlug
@@ -80,14 +85,14 @@ export interface BackpopulateFieldOptions<
 }
 
 export function BackpopulateField<TSlug extends keyof Config['collections']>({
+  name,
   relationFrom,
   relationField,
   collectionSlug,
   label,
 }: BackpopulateFieldOptions<TSlug>): Field {
-  relationFrom
   return {
-    name: `backpopulate_${relationFrom}_${relationField}`,
+    name: name,
     type: 'relationship',
     label: label,
     admin: {

--- a/cms/src/payload-types.ts
+++ b/cms/src/payload-types.ts
@@ -43,6 +43,7 @@ export interface Organization {
   id: string;
   name: string;
   tags?: 'Civic' | 'Government';
+  backpopulate_projects_organizations?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }

--- a/cms/src/payload-types.ts
+++ b/cms/src/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
 export interface Api {
   id: string;
   name: string;
-  project?: string | Project;
+  backpopulate_projects_apis?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -51,6 +51,7 @@ export interface Pain {
   id: string;
   problem: string;
   organizations?: string[] | Organization[];
+  backpopulate_projects_pains?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -58,6 +59,7 @@ export interface Hackathon {
   id: string;
   name: string;
   organizations?: string[] | Organization[];
+  backpopulate_projects_hackathons?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }

--- a/cms/src/payload-types.ts
+++ b/cms/src/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
 export interface Api {
   id: string;
   name: string;
-  backpopulate_projects_apis?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -43,7 +43,7 @@ export interface Organization {
   id: string;
   name: string;
   tags?: 'Civic' | 'Government';
-  backpopulate_projects_organizations?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -51,7 +51,7 @@ export interface Pain {
   id: string;
   problem: string;
   organizations?: string[] | Organization[];
-  backpopulate_projects_pains?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -59,7 +59,7 @@ export interface Hackathon {
   id: string;
   name: string;
   organizations?: string[] | Organization[];
-  backpopulate_projects_hackathons?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }

--- a/web/src/@types/payload-types.ts
+++ b/web/src/@types/payload-types.ts
@@ -40,11 +40,12 @@ export interface Project {
   createdAt: string
 }
 export interface Organization {
-  id: string
-  name: string
-  tags?: 'Civic' | 'Government'
-  updatedAt: string
-  createdAt: string
+  id: string;
+  name: string;
+  tags?: 'Civic' | 'Government';
+  backpopulate_projects_organizations?: string[] | Project[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface Pain {
   id: string

--- a/web/src/@types/payload-types.ts
+++ b/web/src/@types/payload-types.ts
@@ -7,15 +7,15 @@
 
 export interface Config {
   collections: {
-    apis: Api
-    hackathons: Hackathon
-    organizations: Organization
-    pains: Pain
-    projects: Project
-    services: Service
-    users: User
-  }
-  globals: {}
+    apis: Api;
+    hackathons: Hackathon;
+    organizations: Organization;
+    pains: Pain;
+    projects: Project;
+    services: Service;
+    users: User;
+  };
+  globals: {};
 }
 export interface Api {
   id: string;
@@ -25,19 +25,19 @@ export interface Api {
   createdAt: string;
 }
 export interface Project {
-  id: string
-  name: string
-  slug?: string
+  id: string;
+  name: string;
+  slug?: string;
   description?: {
-    [k: string]: unknown
-  }[]
-  status: 'NOT_STARTED' | 'IN_DEVELOPMENT' | 'RELEASED' | 'DONE'
-  organizations?: string[] | Organization[]
-  apis?: string[] | Api[]
-  pains?: string[] | Pain[]
-  hackathons?: string[] | Hackathon[]
-  updatedAt: string
-  createdAt: string
+    [k: string]: unknown;
+  }[];
+  status: 'NOT_STARTED' | 'IN_DEVELOPMENT' | 'RELEASED' | 'DONE';
+  organizations?: string[] | Organization[];
+  apis?: string[] | Api[];
+  pains?: string[] | Pain[];
+  hackathons?: string[] | Hackathon[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface Organization {
   id: string;
@@ -64,23 +64,23 @@ export interface Hackathon {
   createdAt: string;
 }
 export interface Service {
-  id: string
-  name: string
-  project?: string[] | Project[]
-  apis?: string[] | Api[]
-  updatedAt: string
-  createdAt: string
+  id: string;
+  name: string;
+  project?: string[] | Project[];
+  apis?: string[] | Api[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface User {
-  id: string
-  updatedAt: string
-  createdAt: string
-  email?: string
-  resetPasswordToken?: string
-  resetPasswordExpiration?: string
-  salt?: string
-  hash?: string
-  loginAttempts?: number
-  lockUntil?: string
-  password?: string
+  id: string;
+  updatedAt: string;
+  createdAt: string;
+  email?: string;
+  resetPasswordToken?: string;
+  resetPasswordExpiration?: string;
+  salt?: string;
+  hash?: string;
+  loginAttempts?: number;
+  lockUntil?: string;
+  password?: string;
 }

--- a/web/src/@types/payload-types.ts
+++ b/web/src/@types/payload-types.ts
@@ -18,11 +18,11 @@ export interface Config {
   globals: {}
 }
 export interface Api {
-  id: string
-  name: string
-  project?: string | Project
-  updatedAt: string
-  createdAt: string
+  id: string;
+  name: string;
+  backpopulate_projects_apis?: string[] | Project[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface Project {
   id: string
@@ -48,18 +48,20 @@ export interface Organization {
   createdAt: string;
 }
 export interface Pain {
-  id: string
-  problem: string
-  organizations?: string[] | Organization[]
-  updatedAt: string
-  createdAt: string
+  id: string;
+  problem: string;
+  organizations?: string[] | Organization[];
+  backpopulate_projects_pains?: string[] | Project[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface Hackathon {
-  id: string
-  name: string
-  organizations?: string[] | Organization[]
-  updatedAt: string
-  createdAt: string
+  id: string;
+  name: string;
+  organizations?: string[] | Organization[];
+  backpopulate_projects_hackathons?: string[] | Project[];
+  updatedAt: string;
+  createdAt: string;
 }
 export interface Service {
   id: string

--- a/web/src/@types/payload-types.ts
+++ b/web/src/@types/payload-types.ts
@@ -20,7 +20,7 @@ export interface Config {
 export interface Api {
   id: string;
   name: string;
-  backpopulate_projects_apis?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -43,7 +43,7 @@ export interface Organization {
   id: string;
   name: string;
   tags?: 'Civic' | 'Government';
-  backpopulate_projects_organizations?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -51,7 +51,7 @@ export interface Pain {
   id: string;
   problem: string;
   organizations?: string[] | Organization[];
-  backpopulate_projects_pains?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }
@@ -59,7 +59,7 @@ export interface Hackathon {
   id: string;
   name: string;
   organizations?: string[] | Organization[];
-  backpopulate_projects_hackathons?: string[] | Project[];
+  projects?: string[] | Project[];
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Purpose
To display back-reference to other collections containing this document in a relationship field

## What it is
It's a read-only relationship field which displays documents that references the current document. For example, `Projects` contains a relationship field to `Organization`. Normally, in `Organization` edit view, we cannot see which `Projects` are linked to this `Organization`. This field help display those `Projects` in a read-only style relationship field.
<img width="1074" alt="image" src="https://github.com/kaogeek/hack-th/assets/24814968/5c93d9d3-999d-42aa-983c-9b9ed46ebf0c">

## Future TODOs
I originally planned to get current collection slug in hooks using the hook's argument args, but there seems to be bug (or I messed up), so I'm adding current collection slug as the option for now as a temporary workaround.

## Note
This field will create additional fields in MongoDB with null value, but can be safely ignored as the value will be replaced by an afterRead hook. This shouldn't matter at all for average users unless you have direct access to MongoDB instance 
<img width="606" alt="image" src="https://github.com/kaogeek/hack-th/assets/24814968/af1f87eb-6700-46ee-8091-6a1ceb5940b1">
